### PR TITLE
switching from mobeel fat aar plugin to kezong fat aar plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ buildscript {
       exclude group: 'org.codehaus.groovy', module: 'groovy-all'
     }
     classpath 'net.ltgt.gradle:gradle-apt-plugin:0.21'
-    classpath 'gradle.plugin.com.mobbeel.plugin:mobbeel-fataar:1.2.0'
+    // classpath 'gradle.plugin.com.mobbeel.plugin:mobbeel-fataar:1.2.0'
+    classpath 'com.kezong:fat-aar:1.2.19'
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
   }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
 apply plugin: 'jacoco-android'
 apply plugin: 'net.ltgt.apt'
-apply plugin: 'com.mobbeel.plugin'
+//apply plugin: 'com.mobbeel.plugin'
+apply plugin: 'com.kezong.fat-aar'
 apply from: '../config/quality.gradle'
 apply from: '../maven_push.gradle'
 
@@ -56,9 +57,11 @@ jacocoAndroidUnitTestReport {
   xml.enabled true
 }
 
-fatAARConfig {
-  includeAllInnerDependencies false
-}
+//fatAARConfig {
+//  includeAllInnerDependencies false
+//}
+
+configurations.embed.transitive = false
 
 dependencies {
   api deps.thinkgear


### PR DESCRIPTION
mobeel plugin does not work with the recent gradle version)

note: this needs to be tested (with newer gradle build tools version) and then commented out code should be removed